### PR TITLE
4B-分片迁移+配置更新

### DIFF
--- a/src/shardkv/common.go
+++ b/src/shardkv/common.go
@@ -56,5 +56,5 @@ type PullShardArgs struct {
 type PullShardReply struct {
 	Err   Err
 	Shard int
-	data  map[string]string
+	Data  map[string]string
 }

--- a/src/shardkv/common.go
+++ b/src/shardkv/common.go
@@ -57,4 +57,6 @@ type PullShardReply struct {
 	Err   Err
 	Shard int
 	Data  map[string]string
+	//幂等需要
+	LastApplyUniqId map[int]int64
 }

--- a/src/shardkv/common.go
+++ b/src/shardkv/common.go
@@ -14,6 +14,7 @@ const (
 	ErrNoKey       = "ErrNoKey"
 	ErrWrongGroup  = "ErrWrongGroup"
 	ErrWrongLeader = "ErrWrongLeader"
+	ConfigOutDate  = "ConfigOutDate"
 )
 
 type Err string
@@ -48,10 +49,12 @@ type GetReply struct {
 }
 
 type PullShardArgs struct {
-	Shard int
+	Shard     int
+	ConfigNum int
 }
 
 type PullShardReply struct {
-	Err Err
-	data map[string]string
+	Err   Err
+	Shard int
+	data  map[string]string
 }

--- a/src/shardkv/server.go
+++ b/src/shardkv/server.go
@@ -324,11 +324,12 @@ func (kv *ShardKV) applyEntry() {
 								}
 								kv.outShards[kv.config.Num][shard] = backup
 							} else if gid == kv.gid {
-								//分片增加
-								kv.comeInShards[shard] = config.Groups[gid]
+								//分片增加，需要从旧的group上面去拉配置
 								//0是特殊的GID，不需要备份也不需要拉取配置
 								if curGid == 0 {
 									kv.validShards[shard] = true
+								} else {
+									kv.comeInShards[shard] = kv.config.Groups[curGid]
 								}
 							}
 						}

--- a/src/shardkv/test_test.go
+++ b/src/shardkv/test_test.go
@@ -1,6 +1,8 @@
 package shardkv
 
-import "6.824/porcupine"
+import (
+	"6.824/porcupine"
+)
 import "6.824/models"
 import "testing"
 import "strconv"
@@ -24,6 +26,8 @@ func check(t *testing.T, ck *Clerk, key string, value string) {
 // test static 2-way sharding, without shard movement.
 //
 func TestStaticShards(t *testing.T) {
+	//debugger := util.Debugger{}
+	//debugger.StartHTTPDebugger()
 	fmt.Printf("Test: static shards ...\n")
 
 	cfg := make_config(t, 3, false, -1)


### PR DESCRIPTION
## 配置拉取
- 保证每个副本都能够更新到最新的配置且保证更新配置的时序性(提交到raft)
- 每次配置更新后需要对需要移除的分片进行backup，方便后来者进行拉取
- 配置的更新需要按版本号逐个更新，不然会导致上面的backup缺失

## 分片数据迁移
- 需要保证和log的全局时序性(需要提交到raft)
- 需要有一个拉取分片的记录，让每个节点主动去拉去分片，并且在leader发生变更的时候继续拉取
